### PR TITLE
feat: Display IPv6 addresses and list multiple IPs on separate lines

### DIFF
--- a/jmore
+++ b/jmore
@@ -149,8 +149,9 @@ then
 fi
 
 (
-  echo "JAIL JID TYPE VER DIR IFACE IP(s)"
-  echo "---- --- ---- --- --- ----- -----"
+  printf "%-28s %-4s %-5s %-7s %-15s %-15s %s\n" "JAIL" "JID" "TYPE" "VER" "DIR" "IFACE" "IP(s)"
+  printf "%-28s %-4s %-5s %-7s %-15s %-15s %s\n" "----" "---" "----" "---" "---" "-----" "-----"
+
   grep -h '^[^#]' \
     /etc/jail.conf \
     /etc/jail.conf.d/* \
@@ -194,12 +195,11 @@ fi
           DIR="[GONE]${DIR}"
         fi
 
-        IPS=$( jexec ${JAIL} env IFCONFIG_FORMAT=inet:cidr ifconfig 2> /dev/null \
-                 | grep 'inet ' \
-                 | grep -v 127.0.0.1 \
-                 | awk '{print $2}' \
-                 | tr '\n' '+' \
-                 | sed '$s/.$//' )
+        IPS=$( jexec "${JAIL}" ifconfig 2>/dev/null \
+          | awk '
+              $1 == "inet"  && $2 != "127.0.0.1"            { print $2 }
+              $1 == "inet6" && $2 !~ /^fe80/ && $2 != "::1" { print $2 }
+            ' | tr '\n' '+' | sed 's/+$//' )
 
         TYPE=$( jexec ${JAIL} sysctl -n security.jail.vnet 2> /dev/null )
 
@@ -273,9 +273,16 @@ EOF_IP
         [ "${IPS}"   = "" ] && IPS='-'
         [ "${VER}"   = "" ] && VER='-'
 
-        echo ${JAIL} ${JID} ${TYPE} ${VER} ${DIR} ${IFACE} ${IPS}
+        FIRST_IP=$( echo "${IPS}" | tr '+' '\n' | head -1 )
+        REST_IPS=$( echo "${IPS}" | tr '+' '\n' | tail -n +2 )
+
+        printf "%-28s %-4s %-5s %-7s %-15s %-15s %s\n" "${JAIL}" "${JID}" "${TYPE}" "${VER}" "${DIR}" "${IFACE}" "${FIRST_IP}"
+
+        for ip in ${REST_IPS}; do
+          printf "%80s%s\n" "" "$ip"  # 80 = width of 6 previous fields
+        done
 
         unset JAIL JID TYPE VER DIR IFACE IPS
 
       done
-) | column -t
+)


### PR DESCRIPTION
This PR updates the jmore script to enhance its network information display for FreeBSD jails.

Motivation:

The original script was a helpful tool for viewing jail information but had a couple of areas for improvement regarding network details:

It did not display IPv6 addresses assigned to jails.
When a jail possessed multiple IP addresses, they were all listed on a single line, which could be difficult to parse quickly.

Changes Implemented:

IPv6 Address Collection:
The IPS variable assignment now incorporates an awk script that processes the output of jexec "${JAIL}" ifconfig.
This awk script collects both inet (IPv4) addresses (excluding 127.0.0.1) and inet6 (IPv6) addresses.
IPv6 link-local addresses (starting with fe80:) and the IPv6 loopback address (::1) are filtered out.
The gathered IPs are then converted into the +-separated string format that the script uses internally.

Formatted Output with Multi-line IP Display:
The script now uses printf with fixed-width specifiers for printing the header and the main information line for each jail. This provides more direct control over the initial column layout.

If a jail has multiple IP addresses:
The first IP address is displayed on the primary information line for the jail.
Any additional IP addresses (REST_IPS) are iterated and printed on new, subsequent lines. These subsequent IP lines are prepended with a fixed number of spaces using printf "%80s%s\n" "" "$ip" to indent them.

Benefits:
Enhanced IP Information: Provides a more complete view of jail networking by including relevant IPv6 addresses.
Improved Readability for Multiple IPs: Listing each IP address on its own line, with subsequent IPs indented, makes it easier to see all assigned addresses for a jail.
Minimal Core Changes: The modifications are focused on IP data collection and the output formatting within each jail's processing, largely preserving the original script's overall structure and command execution logic.

Testing:
Tested on FreeBSD 14.2-RELEASE

Verified with jails having:
- Only IPv4 addresses.
- Only IPv6 addresses (global/ULA, excluding link-local/loopback).
- A mix of multiple IPv4 and IPv6 addresses.
- No IP addresses.


Example output: ![Bildschirmfoto_20250517_194909](https://github.com/user-attachments/assets/01f8249e-533f-4d48-9e6e-16d18cd07676)

Confirmed that the output structure displays IPs on separate lines with the described indentation.
This change aims to make jmore more informative and user-friendly for jails with IPv6 and/or multiple IP configurations.

If you find this PR helpful, feel free to accept/modify and use if as you want :-)